### PR TITLE
fix: duplicate link in deleted comments

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Unedit and Undelete for Reddit
 // @namespace    http://tampermonkey.net/
-// @version      3.7.2
+// @version      3.7.3
 // @description  Creates the option next to edited and deleted Reddit comments/posts to show the original comment from before it was edited
 // @author       Jonah Lawrence (DenverCoder1)
 // @match        *://*reddit.com/*
@@ -318,7 +318,7 @@
         var editedComments = [];
         // redesign
         if (!isOldReddit) {
-            elementsToCheck = Array.from(document.querySelectorAll(".Comment div span:not(.found)"));
+            elementsToCheck = Array.from(document.querySelectorAll(".Comment div:first-of-type span span:not(.found)"));
             editedComments = elementsToCheck.filter(function (el) {
                 return (
                     el.innerText.substring(0, 6) == "edited" || // include edited comments


### PR DESCRIPTION
Remove duplicate links appearing in the body of deleted comments

before
![image](https://user-images.githubusercontent.com/20955511/172481496-e6d03e8c-9c87-442c-8e69-0e648a0e03c5.png)

after
![image](https://user-images.githubusercontent.com/20955511/172481577-8bfd5550-47a5-4744-be2d-1a81320e7c3b.png)
