### PR TITLE
feat: Support for edited submissions on Redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://addons.mozilla.org/en-US/firefox/addon/unedit-for-reddit/">
     <img src="https://custom-icon-badges.herokuapp.com/amo/v/unedit-for-reddit?color=FF7139&label=firefox&logo=firefoxpng" alt="Firefox" /></a>
   <a href="https://greasyfork.org/en/scripts/407466-unedit-and-undelete-for-reddit">
-    <img src="https://custom-icon-badges.herokuapp.com/github/v/release/DenverCoder1/Unedit-for-Reddit?color=000&label=greasyfork&logo=greasyforkpng" alt="Greasyfork" /></a>
+    <img src="https://custom-icon-badges.herokuapp.com/github/v/release/DenverCoder1/Unedit-for-Reddit?color=000&label=greasy+fork&logo=greasyforkpng" alt="Greasy Fork" /></a>
 </p>
 
 Creates a link next to edited and deleted Reddit comments and submissions to show the original post from before it was edited/removed.
@@ -35,7 +35,7 @@ The [Pushshift Reddit API](https://github.com/pushshift/api) is used for fetchin
 
 ### As a Userscript
 
-This script can be installed to most browsers using userscript browser extensions such as [Violentmonkey](https://violentmonkey.github.io/), [Tampermonkey](https://www.tampermonkey.net/), among others using the green button on [Greasy Fork](https://greasyfork.org/en/scripts/407466-unedit-and-undelete-for-reddit).
+This script can be installed on most browsers using userscript browser extensions such as [Violentmonkey](https://violentmonkey.github.io/), [Tampermonkey](https://www.tampermonkey.net/), among others using the green button on [Greasy Fork](https://greasyfork.org/en/scripts/407466-unedit-and-undelete-for-reddit).
 
 Alternatively, you may copy the contents of [`script.js`](https://github.com/DenverCoder1/Unedit-for-Reddit/blob/master/script.js) into a new script using any userscript browser extension.
 
@@ -71,7 +71,7 @@ The following are known limitations that cannot be fixed:
 
 ## Changes in 3.9.0
 
--   Support for edited submission on Reddit Redesign on page of submission, list view, and popup view
+-   Support for edited submissions on Reddit Redesign on submission pages, list view, and popup view
 -   Displays how long ago submissions were edited on Redesign since Reddit doesn't display this information
 -   Minor code refactoring and added comments
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ The following are known limitations that cannot be fixed:
 
 ## Changelog
 
+## Changes in 3.9.0
+
+-   Support for edited submission on Reddit Redesign on page of submission, list view, and popup view
+-   Displays how long ago submissions were edited on Redesign since Reddit doesn't display this information
+-   Minor code refactoring and added comments
+
 ### Changes in 3.8.0
 
 -   Added support for viewing deleted and moderator-removed submissions on Redesign and Old Reddit

--- a/manifest-v2.json
+++ b/manifest-v2.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Unedit and Undelete for Reddit",
     "description": "Creates links next to edited and deleted Reddit posts to show the original from before it was edited/removed.",
-    "version": "3.8.0",
+    "version": "3.9.0",
     "content_scripts": [
         {
             "run_at": "document_idle",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Unedit and Undelete for Reddit",
     "description": "Creates links next to edited and deleted Reddit posts to show the original from before it was edited/removed.",
-    "version": "3.8.0",
+    "version": "3.9.0",
     "content_scripts": [
         {
             "run_at": "document_idle",

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Unedit and Undelete for Reddit
 // @namespace    http://tampermonkey.net/
-// @version      3.8.0
+// @version      3.9.0
 // @description  Creates the option next to edited and deleted Reddit comments/posts to show the original comment from before it was edited
 // @author       Jonah Lawrence (DenverCoder1)
 // @match        *://*reddit.com/*

--- a/script.js
+++ b/script.js
@@ -165,10 +165,9 @@
         // redesign
         if (!isOldReddit) {
             baseEl = document.querySelector(`#${postId}, .Comment.${postId}`);
-            // in post preview popups, the id will appear again but without the .scrollerItem class
-            if (document.querySelector(`.Post.${postId}:not(.scrollerItem)`)) {
-                baseEl = document.querySelector(`.Post.${postId}:not(.scrollerItem)`);
-            }
+            // in post preview popups, the id will appear again but in #overlayScrollContainer
+            const popupEl = document.querySelector(`#overlayScrollContainer .Post.${postId}`);
+            baseEl = popupEl ? popupEl : baseEl;
             if (baseEl) {
                 if (baseEl.getElementsByClassName("RichTextJSON-root").length > 0) {
                     bodyEl = baseEl.getElementsByClassName("RichTextJSON-root")[0];
@@ -258,8 +257,14 @@
                 origBodyEl.scrollIntoView({ behavior: "smooth" });
             }
         }, 500);
-        // on old reddit, if the comment is collapsed, expand it so the original comment is visible
-        if (isOldReddit) {
+        // Redesign
+        if (!isOldReddit) {
+            // Make sure collapsed submission previews are expanded to not hide the original comment.
+            commentBodyElement.parentElement.style.maxHeight = "unset";
+        }
+        // Old reddit
+        else {
+            // If the comment is collapsed, expand it so the original comment is visible
             expandComment(commentBodyElement);
         }
     }
@@ -449,7 +454,7 @@
         if (!isOldReddit) {
             // check for edited/deleted comments and deleted submissions
             selectors = [
-                ".Comment div:first-of-type span span:not(.found)", // Comments "edited..." or "Comment deleted/removed..."
+                ".Comment div:first-of-type span:not(.found)", // Comments "edited..." or "Comment deleted/removed..."
                 ".Post div div div:last-of-type div ~ div:last-of-type:not(.found)", // Submissions "It doesn't appear in any feeds..." message
             ];
             elementsToCheck = Array.from(document.querySelectorAll(selectors.join(", ")));
@@ -469,7 +474,8 @@
                 const editedAt = submission.edited;
                 selectors = [
                     `#t3_${postId} > div:first-of-type > div:nth-of-type(2) > div:first-of-type > div:first-of-type > span:nth-of-type(3):not(.found)`, // Submission page
-                    `#t3_${postId} > div:last-of-type[data-click-id] > div:first-of-type > div:first-of-type > div:first-of-type:not(.found)`, // Listing view
+                    `#t3_${postId} > div:last-of-type[data-click-id] > div:first-of-type > div:first-of-type > div:first-of-type:not(.found)`, // Subreddit listing view
+                    `.Post.t3_${postId} > div:last-of-type[data-click-id] > div:first-of-type > div:nth-of-type(2) > div:first-of-type:not(.found)`, // Profile/home listing view
                     `.Post.t3_${postId}:not(.scrollerItem) > div:first-of-type > div:nth-of-type(2) > div:nth-of-type(2) > div:first-of-type > div:first-of-type:not(.found)`, // Preview popup
                 ];
                 Array.from(document.querySelectorAll(selectors.join(", "))).forEach((el) => {

--- a/script.js
+++ b/script.js
@@ -461,11 +461,12 @@
             editedComments = elementsToCheck.filter(function (el) {
                 el.classList.add("found");
                 return (
-                    el.innerText.substring(0, 6) === "edited" || // include edited comments
-                    el.innerText.substring(0, 15) === "Comment deleted" || // include comments deleted by user
-                    el.innerText.substring(0, 15) === "Comment removed" || // include comments removed by moderator
-                    el.innerText.substring(0, 30) === "It doesn't appear in any feeds" || // include deleted submissions
-                    el.innerText.substring(0, 23) == "Moderators remove posts" // include submissions removed by moderators
+                    !el.children.length && // we only care about the element if it has no children
+                    (el.innerText.substring(0, 6) === "edited" || // include edited comments
+                        el.innerText.substring(0, 15) === "Comment deleted" || // include comments deleted by user
+                        el.innerText.substring(0, 15) === "Comment removed" || // include comments removed by moderator
+                        el.innerText.substring(0, 30) === "It doesn't appear in any feeds" || // include deleted submissions
+                        el.innerText.substring(0, 23) == "Moderators remove posts") // include submissions removed by moderators
                 );
             });
             // Edited submissions found using the Reddit API

--- a/script.js
+++ b/script.js
@@ -517,8 +517,12 @@
             });
         }
         // create links
-        editedComments.forEach(function (x) {
-            createLink(x);
+        editedComments.forEach(function (el) {
+            // for removed submissions, add the link to an element in the tagline instead of the body
+            if (el.closest(".usertext-body") && el.innerText === "[removed]") {
+                el = el.closest(".entry")?.querySelector("p.tagline span:first-of-type") || el;
+            }
+            createLink(el);
         });
     }
 

--- a/script.js
+++ b/script.js
@@ -543,11 +543,18 @@
      * we will check the data in the Reddit JSON API for the information.
      */
     function checkForEditedSubmissions() {
+        // don't need to check if we're not on a submission page or list view
+        if (!document.querySelector(".Post, .ListingLayout-backgroundContainer")) {
+            return;
+        }
         const pattern = new URLPattern(window.location.href);
         const jsonUrl = `https://www.reddit.com${pattern.pathname}.json?${pattern.search}`;
         logging.info(`Fetching additional info from ${jsonUrl}`);
         fetch(jsonUrl)
             .then(function (response) {
+                if (!response.ok) {
+                    throw new Error(`${response.status} ${response.statusText}`);
+                }
                 return response.json();
             })
             .then(function (data) {
@@ -568,6 +575,9 @@
                     logging.info("Edited submissions:", editedSubmissions);
                     setTimeout(findEditedComments, 1000);
                 }
+            })
+            .catch(function (error) {
+                logging.error("Error fetching additional info:", error);
             });
     }
 

--- a/script.js
+++ b/script.js
@@ -454,6 +454,8 @@
                 "beforeend",
                 "<style>p.og pre { font-family: monospace; background: #fff59d; padding: 6px; margin: 6px 0; color: black; } p.og h1 { font-size: 2em; } p.og h2 { font-size: 1.5em; } p.og > h3:first-child { font-weight: bold; margin-bottom: 0.5em; } p.og h3 { font-size: 1.17em; } p.og h4 { font-size: 1em; } p.og h5 { font-size: 0.83em; } p.og h6 { font-size: 0.67em; } p.og a { color: lightblue; text-decoration: underline; }</style>"
             );
+                    });
+            }
         }
         // find edited comments
         findEditedComments();


### PR DESCRIPTION
Features:

* On reddit redesign, edited submissions will be able to be fetched
	* when viewing on the page of the submission itself
	* when viewing a list of posts, eg a subreddit or the home page
	* when viewing a popup preview of a submission
* How long ago the post was edited will be displayed next to the time since Reddit doesn't display this info normally

Points to address:
~* List view is a bit unreliable, posts (eg. on /top without specifying range) are sometimes not found in the json request~
~* When switching to a new list view (eg. switching from hot to top, etc.), does not check for edited posts in the new results.~