### PR TITLE
fix: only show original if it's not already shown

### DIFF
--- a/script.js
+++ b/script.js
@@ -268,7 +268,9 @@
         // append to original comment
         origBodyEl.appendChild(document.createElement("hr"));
         origBodyEl.appendChild(detailsEl);
-        commentBodyElement.appendChild(origBodyEl);
+        if (commentBodyElement.lastElementChild.className !== 'og') {
+            commentBodyElement.appendChild(origBodyEl);
+        }
         // scroll into view
         setTimeout(function () {
             if (!isInViewport(origBodyEl)) {


### PR DESCRIPTION
Sometimes there are still multiple ways to show original (eg. a post that was edited and then removed).

This makes it so that the og paragraph never appears twice if both links are clicked