### PR TITLE
feat: superscript, spoilers, strikethrough, links,and other markdown enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,19 @@ The following are known limitations that cannot be fixed:
 
 ## Changelog
 
+### Changes in 3.11.0
+
+-   Fix markdown conversion to include strikethrough, Github-style code blocks, indented sublists without 4 spaces, and underscores in the middle of a word
+-   Added links where username and subreddit mentions appear in the original post
+-   Added support for hiding spoiler text in the original post
+-   Added support for superscripts using `^` in the original post
+
 ### Changes in 3.10.0
 
 -   Added color overrides for compatibility with RES Night Mode and more custom CSS themes on Old Reddit
 -   Added extra spacing around paragraphs and headings in the original comment
--   Improved styling of codeblocks in the original comment on Reddit Redesign
--   Added support for displaying tables in original comment
+-   Improved styling of code blocks in the original comment on Reddit Redesign
+-   Added support for displaying tables in the original comment
 
 ### Changes in 3.9.5
 

--- a/manifest-v2.json
+++ b/manifest-v2.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
     "name": "Unedit and Undelete for Reddit",
-    "description": "Creates links next to edited and deleted Reddit posts to show the original from before it was edited/removed.",
-    "version": "3.10.0",
+    "description": "Show original comments and posts from before they were edited or removed",
+    "version": "3.11.0",
     "content_scripts": [
         {
             "run_at": "document_idle",

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 3,
     "name": "Unedit and Undelete for Reddit",
-    "description": "Creates links next to edited and deleted Reddit posts to show the original from before it was edited/removed.",
-    "version": "3.10.0",
+    "description": "Show original comments and posts from before they were edited or removed",
+    "version": "3.11.0",
     "content_scripts": [
         {
             "run_at": "document_idle",

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Unedit and Undelete for Reddit
 // @namespace    http://tampermonkey.net/
-// @version      3.10.0
+// @version      3.11.0
 // @description  Creates the option next to edited and deleted Reddit comments/posts to show the original comment from before it was edited
 // @author       Jonah Lawrence (DenverCoder1)
 // @match        https://reddit.com/*
@@ -56,7 +56,14 @@
      * Showdown markdown converter
      * @type {showdown.Converter}
      */
-    const mdConverter = new showdown.Converter({ tables: true });
+    const mdConverter = new showdown.Converter({
+        tables: true,
+        simplifiedAutoLink: true,
+        literalMidWordUnderscores: true,
+        strikethrough: true,
+        ghCodeBlocks: true,
+        disableForced4SpacesIndentedSublists: true,
+    });
 
     /**
      * Logging methods for displaying formatted logs in the console.
@@ -231,24 +238,40 @@
     }
 
     /**
+     * Generate HTML from markdown for a comment or submission.
+     * @param {string} postType The type of post - "comment" or "post" (submission)
+     * @param {string} original The markdown to convert
+     * @returns {string} The HTML of the markdown
+     */
+    function redditPostToHTML(postType, original) {
+        // fix Reddit tables to have at least two dashes per cell in the alignment row
+        let body = original.replace(/(?<=^\s*|\|\s*)(:?)-(:?)(?=\s*\|[-|\s:]*$)/g, "$1--$2");
+        // convert superscripts in the form "^(some text)" or "^text" to <sup>text</sup>
+        body = body.replace(/\^\((.+?)\)/g, "<sup>$1</sup>").replace(/\^(\S+)/g, "<sup>$1</sup>");
+        // convert user and subreddit mentions to links (can be /u/, /r/, u/, or r/)
+        body = body.replace(/(?<=^|[^\w\/])(\/?)([ur]\/\w+)/g, "[$1$2](/$2)");
+        // convert markdown to HTML
+        let html = mdConverter.makeHtml("\n\n### Original " + postType + ":\n\n" + body);
+        // convert Reddit spoilertext
+        return html.replace(
+            /(?<=^|\s|>)&gt;!(.+?)!&lt;(?=$|\s|<)/g,
+            "<span class='md-spoiler-text' title='Reveal spoiler'>$1</span>"
+        );
+    }
+
+    /**
      * Create a new paragraph containing the body of the original comment/post.
      * @param {Element} commentBodyElement The container element of the comment/post body.
      * @param {string} postType The type of post - "comment" or "post" (submission)
      * @param {object} postData The archived data of the original comment/post.
      */
     function showOriginalComment(commentBodyElement, postType, postData) {
-        let originalBody = typeof postData?.body === "string" ? postData.body : postData?.selftext;
+        const originalBody = typeof postData?.body === "string" ? postData.body : postData?.selftext;
         // create paragraph element
         const origBodyEl = document.createElement("p");
         origBodyEl.className = "og";
-        // fix Reddit tables to have at least two dashes per cell in the alignment row
-        originalBody = originalBody.replace(/(?<=^\s*|\|\s*)(:?)-(:?)(?=\s*\|)/g, function (match, p1, p2) {
-            // p1 is the first colon or empty, p2 is the second colon or empty
-            // if there is at least one colon, replace the dash with two dashes
-            return p1 || p2 ? `${p1}--${p2}` : match;
-        });
         // set text
-        origBodyEl.innerHTML = mdConverter.makeHtml("\n\n### Original " + postType + ":\n\n" + originalBody);
+        origBodyEl.innerHTML = redditPostToHTML(postType, originalBody);
         // author and date details
         const detailsEl = document.createElement("div");
         detailsEl.style.fontSize = "12px";
@@ -685,7 +708,35 @@
                         border: 1px solid black;
                         padding: 4px;
                     }
+                    p.og sup {
+                        position: relative;
+                        font-size: .7em;
+                        line-height: .7em;
+                        top: -0.4em;
+                    }
+                    span.md-spoiler-text {
+                        background: #545452;
+                        border-radius: 2px;
+                        transition: background 1s ease-out;
+                        cursor: pointer;
+                        color: #545452;
+                    }
+                    span.md-spoiler-text.revealed {
+                        background: rgba(84,84,82,.1);
+                        color: inherit;
+                    }
                 </style>`
+            );
+            // listen for spoilertext in original body to be revealed
+            window.addEventListener(
+                "click",
+                function (e) {
+                    const spoiler = e.target.closest("span.md-spoiler-text");
+                    if (spoiler) {
+                        spoiler.classList.add("revealed");
+                    }
+                },
+                false
             );
             // check for edited submissions
             checkForEditedSubmissions();

--- a/script.js
+++ b/script.js
@@ -264,10 +264,12 @@
         // convert markdown to HTML
         let html = mdConverter.makeHtml("\n\n### Original " + postType + ":\n\n" + body);
         // convert Reddit spoilertext
-        return html.replace(
+        html = html.replace(
             /(?<=^|\s|>)&gt;!(.+?)!&lt;(?=$|\s|<)/gm,
             "<span class='md-spoiler-text' title='Reveal spoiler'>$1</span>"
         );
+        // replace &#x200B; with a zero-width space
+        return html.replace(/&amp;#x200B;/g, "\u200B");
     }
 
     /**
@@ -763,9 +765,14 @@
             window.addEventListener(
                 "click",
                 function (e) {
+                    /**
+                     * @type {HTMLSpanElement}
+                     */
                     const spoiler = e.target.closest("span.md-spoiler-text");
                     if (spoiler) {
                         spoiler.classList.add("revealed");
+                        spoiler.removeAttribute("title");
+                        spoiler.style.cursor = "auto";
                     }
                 },
                 false
@@ -810,6 +817,12 @@
                     }
                     p.og table tr {
                         background: none !important;
+                    }
+                    p.og strong {
+                        font-weight: 600;
+                    }
+                    p.og em {
+                        font-style: italic;
                     }
                     /* Override for RES Night mode */
                     .res-nightmode .entry.res-selected .md-container > .md p.og,

--- a/script.js
+++ b/script.js
@@ -736,6 +736,27 @@
                         background: rgba(84,84,82,.1);
                         color: inherit;
                     }
+                    p.og em {
+                        font-style: italic;
+                    }
+                    p.og strong {
+                        font-weight: bold;
+                    }
+                    p.og blockquote {
+                        border-left: 4px solid #c5c1ad;
+                        padding: 0 8px;
+                        margin-left: 5px;
+                        margin-top: 0.35714285714285715em;
+                        margin-bottom: 0.35714285714285715em;
+                    }
+                    p.og ol {
+                        list-style: auto;
+                        margin-left: 1.5em;
+                    }
+                    p.og ul {
+                        list-style: initial;
+                        margin-left: 1.5em;
+                    }
                 </style>`
             );
             // listen for spoilertext in original body to be revealed


### PR DESCRIPTION
-   Fix markdown conversion to include strikethrough, Github-style code blocks, indented sublists without 4 spaces, and underscores in the middle of a word
-   Added links where username and subreddit mentions appear in the original post
-   Added support for hiding spoiler text in the original post
-   Added support for superscripts using `^` in the original post