### PR TITLE
fix: Check parent post if no author and avoid invalid queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The following are known limitations that cannot be fixed:
 
 -   Added support for comments not shown in the comment tree if the link is visited directly.
 -   Added missing `showdown.min.js.map` file to `/vendor` to avoid Source Map error (Browser Extension only).
+-   Avoids sending queries with the author being undefined, and checks the parent post if the author is not known.
 
 ### Changes in 3.14.0
 

--- a/script.js
+++ b/script.js
@@ -432,6 +432,7 @@
                     return;
                 }
                 // create url for getting comment/post from pushshift api
+                const URLs = [];
                 const idURL = isInSubmission(this)
                     ? "https://api.pushshift.io/reddit/search/submission/?ids=" +
                       postId +
@@ -439,35 +440,47 @@
                     : "https://api.pushshift.io/reddit/search/comment/?ids=" +
                       postId +
                       "&sort=desc&sort_type=created_utc&fields=body,author,id,link_id,created_utc,permalink";
+                URLs.push(idURL);
                 // create url for getting author comments/posts from pushshift api
                 const author = this.parentElement.querySelector("a[href*=user]")?.innerText;
-                const authorURL = isInSubmission(this)
-                    ? "https://api.pushshift.io/reddit/search/submission/?author=" +
-                      author +
-                      "&size=200&sort=desc&sort_type=created_utc&fields=selftext,author,id,created_utc,permalink"
-                    : "https://api.pushshift.io/reddit/search/comment/?author=" +
-                      author +
-                      "&size=200&sort=desc&sort_type=created_utc&fields=body,author,id,link_id,created_utc,permalink";
+                if (author) {
+                    const authorURL = isInSubmission(this)
+                        ? "https://api.pushshift.io/reddit/search/submission/?author=" +
+                          author +
+                          "&size=200&sort=desc&sort_type=created_utc&fields=selftext,author,id,created_utc,permalink"
+                        : "https://api.pushshift.io/reddit/search/comment/?author=" +
+                          author +
+                          "&size=200&sort=desc&sort_type=created_utc&fields=body,author,id,link_id,created_utc,permalink";
+                    URLs.push(authorURL);
+                }
+                // if the author is unknown, check the parent post as an alternative instead
+                else if (!isInSubmission(this)) {
+                    const parsedURL = parseURL();
+                    if (parsedURL?.submissionID) {
+                        const parentURL =
+                            "https://api.pushshift.io/reddit/comment/search?q=*&link_id=" +
+                            parsedURL.submissionID +
+                            "&size=200&sort=desc&sort_type=created_utc&fields=body,author,id,link_id,created_utc,permalink";
+                        URLs.push(parentURL);
+                    }
+                }
 
                 // set loading status
                 currentLoading = this;
                 this.innerHTML = "loading...";
 
-                logging.info("Fetching from " + idURL + " and " + authorURL);
+                logging.info(`Fetching from ${URLs.join(" and ")}`);
 
                 // request from pushshift api
-                await Promise.all([
-                    fetch(idURL)
-                        .then((resp) => resp.json())
-                        .catch((error) => {
-                            logging.error("Error:", error);
-                        }),
-                    fetch(authorURL)
-                        .then((resp) => resp.json())
-                        .catch((error) => {
-                            logging.error("Error:", error);
-                        }),
-                ])
+                await Promise.all(
+                    URLs.map((url) =>
+                        fetch(url)
+                            .then((resp) => resp.json())
+                            .catch((error) => {
+                                logging.error("Error:", error);
+                            })
+                    )
+                )
                     .then((responses) => {
                         responses.forEach((out) => {
                             // locate the comment that was being loaded

--- a/script.js
+++ b/script.js
@@ -434,33 +434,22 @@
                 // create url for getting comment/post from pushshift api
                 const URLs = [];
                 const idURL = isInSubmission(this)
-                    ? "https://api.pushshift.io/reddit/search/submission/?ids=" +
-                      postId +
-                      "&sort=desc&sort_type=created_utc&fields=selftext,author,id,created_utc,permalink"
-                    : "https://api.pushshift.io/reddit/search/comment/?ids=" +
-                      postId +
-                      "&sort=desc&sort_type=created_utc&fields=body,author,id,link_id,created_utc,permalink";
+                    ? `https://api.pushshift.io/reddit/search/submission/?ids=${postId}&fields=selftext,author,id,created_utc,permalink`
+                    : `https://api.pushshift.io/reddit/search/comment/?ids=${postId}&fields=body,author,id,link_id,created_utc,permalink`;
                 URLs.push(idURL);
                 // create url for getting author comments/posts from pushshift api
                 const author = this.parentElement.querySelector("a[href*=user]")?.innerText;
                 if (author) {
                     const authorURL = isInSubmission(this)
-                        ? "https://api.pushshift.io/reddit/search/submission/?author=" +
-                          author +
-                          "&size=200&sort=desc&sort_type=created_utc&fields=selftext,author,id,created_utc,permalink"
-                        : "https://api.pushshift.io/reddit/search/comment/?author=" +
-                          author +
-                          "&size=200&sort=desc&sort_type=created_utc&fields=body,author,id,link_id,created_utc,permalink";
+                        ? `https://api.pushshift.io/reddit/search/submission/?author=${author}&size=200&sort=desc&sort_type=created_utc&fields=selftext,author,id,created_utc,permalink`
+                        : `https://api.pushshift.io/reddit/search/comment/?author=${author}&size=200&sort=desc&sort_type=created_utc&fields=body,author,id,link_id,created_utc,permalink`;
                     URLs.push(authorURL);
                 }
                 // if the author is unknown, check the parent post as an alternative instead
                 else if (!isInSubmission(this)) {
                     const parsedURL = parseURL();
                     if (parsedURL?.submissionID) {
-                        const parentURL =
-                            "https://api.pushshift.io/reddit/comment/search?q=*&link_id=" +
-                            parsedURL.submissionID +
-                            "&size=200&sort=desc&sort_type=created_utc&fields=body,author,id,link_id,created_utc,permalink";
+                        const parentURL = `https://api.pushshift.io/reddit/comment/search?q=*&link_id=${parsedURL.submissionID}&size=200&sort=desc&sort_type=created_utc&fields=body,author,id,link_id,created_utc,permalink`;
                         URLs.push(parentURL);
                     }
                 }


### PR DESCRIPTION
* If author is undefined, avoid making a request to pushshift with author=undefined
* Instead make a request to comments on the parent post if it is not a submission and the submission id is found in the URL